### PR TITLE
fix notations and typos

### DIFF
--- a/src/lec17.2-discrete_time.md
+++ b/src/lec17.2-discrete_time.md
@@ -13,12 +13,12 @@ $$
 $$
 which gives us:
 $$
-\mathbf{A}^n(\mathbf{X}) = \frac{\mathbf{x}^n(\mathbf{X}) - (\mathbf{x}^{n-1}(\mathbf{X}) + h \mathbf{V}^{n-1}(\mathbf{X}))}{\Delta t^2},
+\mathbf{A}^n(\mathbf{X}) = \frac{\mathbf{x}^n(\mathbf{X}) - (\mathbf{x}^{n-1}(\mathbf{X}) + \Delta t \mathbf{V}^{n-1}(\mathbf{X}))}{\Delta t^2},
 $$
 where $\Delta t = t^n - t^{n-1}$. Applying this relation at the sample points into Equation {{eqref: eq:lec17:test_func_chosen}}, we obtain:
 $$
 \begin{aligned}
-& M_{\hat{a}b} \frac{x^n_{b|\hat{i}} - (x^{n-1}_{b|\hat{i}} + h V^{n-1}_{b|\hat{i}})}{\Delta t^2} \\
+& M_{\hat{a}b} \frac{x^n_{b|\hat{i}} - (x^{n-1}_{b|\hat{i}} + \Delta t V^{n-1}_{b|\hat{i}})}{\Delta t^2} \\
 &= \int_{\partial\Omega^0} N_{\hat{a}}(\mathbf{X}) T_{\hat{i}}(\mathbf{X}, t^n) ds(\mathbf{X}) - \int_{\Omega^0} N_{\hat{a},j}(\mathbf{X}) P_{\hat{i}j}(\mathbf{X}, t^n) d\mathbf{X}.
 \end{aligned}
 {{numeq}}{eq:lec17:BE}

--- a/src/lec19.1-linear_disp_field.md
+++ b/src/lec19.1-linear_disp_field.md
@@ -11,7 +11,7 @@ This equation represents a 2D interpolation, extending Experiment {{ref: exp:lec
 
 Linear finite elements use linear shape functions $N_i$ in Equation {{eqref: eq:lec19:2d_interpolation}}, resulting in a piecewise linear (per triangle) displacement field $\mathbf{u} = \hat{\mathbf{x}}(\mathbf{X}) - \mathbf{X}$ over the entire domain. Before providing the precise expression of $N$ in terms of $\mathbf{X}$, we'll introduce another parameter space to simplify the derivation.
 
-Let $\beta, \gamma \in [0,1]$ and $\beta + \gamma = 1$, we can use them to express the material space coordinates of an arbitrary point $\mathbf{X}$ in the element $\mathbf{X}_1 \mathbf{X}_2 \mathbf{X}_3$ as:
+Let $\beta, \gamma \in [0,1]$ and $\beta + \gamma \leq 1$, we can use them to express the material space coordinates of an arbitrary point $\mathbf{X}$ in the element $\mathbf{X}_1 \mathbf{X}_2 \mathbf{X}_3$ as:
 
 $$
 \begin{aligned}

--- a/src/lec19.2-mass_matrix.md
+++ b/src/lec19.2-mass_matrix.md
@@ -21,7 +21,7 @@ Let us change the integration variable from $\mathbf{X}$ to $(\beta, \gamma)$, w
 $$
 \begin{aligned}
 & \int_{\Omega^0_e} R(\mathbf{X},0) N_a(\mathbf{X}) N_b(\mathbf{X}) d\mathbf{X} \\
-=& \int_0^1 \int_0^{1-\beta} R(\beta, \gamma, 0) N_a(\beta, \gamma) N_b(\beta, \gamma) |\det\left(\frac{\partial \mathbf{X}}{\partial (\beta, \gamma)}\right)| d\gamma d\beta.
+=& \int_0^1 \int_0^{1-\beta} R(\beta, \gamma, 0) N_a(\beta, \gamma) N_b(\beta, \gamma) \left|\det\left(\frac{\partial \mathbf{X}}{\partial (\beta, \gamma)}\right)\right| d\gamma d\beta.
 \end{aligned}
 {{numeq}}{eq:lec19:mass_matrix_per_tri_param}
 $$
@@ -29,7 +29,7 @@ $$
 For simplicity, let us denote the vertices of this triangle $e$ as $\mathbf{X}_1$, $\mathbf{X}_2$, and $\mathbf{X}_3$, and then we have:
 
 $$
-|\det\left(\frac{\partial \mathbf{X}}{\partial (\beta, \gamma)}\right)| = |\det([\mathbf{X}_2 - \mathbf{X}_1, \mathbf{X}_3 - \mathbf{X}_1])| = 2 A_e,
+\left|\det\left(\frac{\partial \mathbf{X}}{\partial (\beta, \gamma)}\right)\right| = |\det([\mathbf{X}_2 - \mathbf{X}_1, \mathbf{X}_3 - \mathbf{X}_1])| = 2 A_e,
 $$
 
 where $A_e$ is the area of triangle $e$. Here, $N_a$ and $N_b$ take $1-\beta-\gamma$, $\beta$, or $\gamma$ depending on the vertex indices $a$ and $b$. For example, if $a$ and $b$ correspond to the 2nd and 3rd vertices of triangle $e$, then $N_a = \beta$ and $N_b = \gamma$. Assuming uniform density, we have:
@@ -56,7 +56,7 @@ where $\mathcal{V}$ contains all the nodes of the mesh, and all off-diagonal ent
 
 $$
 \begin{aligned}
-    M_{aa}^\text{lump} & = \sum_{e \in \mathcal{T}(a)} 2 R A_e ( \int_0^1 \int_0^{1-\beta} \beta (1- \beta - \gamma) d\gamma d\beta + \int_0^1 \int_0^{1-\beta} \beta^2 d\gamma d\beta \\ &+ \int_0^1 \int_0^{1-\beta} \beta \gamma d\gamma d\beta ) \\
+    M_{aa}^\text{lump} & = \sum_{e \in \mathcal{T}(a)} 2 R A_e \left( \int_0^1 \int_0^{1-\beta} \beta (1- \beta - \gamma) d\gamma d\beta + \int_0^1 \int_0^{1-\beta} \beta^2 d\gamma d\beta\right. \\ &+ \left.\int_0^1 \int_0^{1-\beta} \beta \gamma d\gamma d\beta \right) \\
     & = \sum_{e \in \mathcal{T}(a)} 2 R A_e \int_0^1 \beta d\gamma d\beta = \sum_{e \in \mathcal{T}(a)} 2 R A_e \int_0^1 \beta \gamma |_{\gamma=0}^{\gamma =1-\beta} d\beta \\
     & = \sum_{e \in \mathcal{T}(a)} 2 R A_e \int_0^1 \beta (1-\beta) d\beta = \sum_{e \in \mathcal{T}(a)} 2 R A_e \left. \left(\frac{\beta^2}{2} - \frac{\beta^3}{3} \right) \right|_{\beta=0}^{\beta=1} \\ 
     &= \sum_{e \in \mathcal{T}(a)} \frac{1}{3} R A_e,


### PR DESCRIPTION
- In 17.2 I guess $h$ should be $\Delta t$ as $h$ is not defined in the context.
- The equality in 19.1 should probably be inequality.
- Fixed paired symbols in 19.2.